### PR TITLE
Add homepage and repo detail in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,10 @@
   },
   "keywords": [],
   "author": "Sean Johnson & Tao Ning & Sam Lau",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/taoning2014/srt-validator",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:taoning2014/srt-validator.git"
+  }
 }


### PR DESCRIPTION
So that the published module in https://www.npmjs.com/package/srt-validator can be linked back to this repo