### PR TITLE
Emit umd build for wider support

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'srtValidator.js',
     library: 'srtValidator',
-    libraryTarget: 'amd',
+    libraryTarget: 'umd',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Right now, the javascript output only support AMD build.

Emitting `umd` build allow to module to be used in a wider context, such as:
- webpack
- nodejs (umd > commonjs)
- web/browser (umd > web)
