### PR TITLE
Don't need - for vtt captioning

### DIFF
--- a/src/srtparser/serialize.js
+++ b/src/srtparser/serialize.js
@@ -21,11 +21,6 @@ export default function serialize(srtChunks, format = 'SRT') {
         ...options,
         FILE_HEADER: `WEBVTT${EOL}${EOL}`,
         MS_SEPERATOR: '.',
-        FORMAT_TEXT: text =>
-          text
-            .split(EOL)
-            .map(line => `- ${line}`)
-            .join(EOL),
       };
       break;
     case 'srt':

--- a/tests/srtparser/serialize.spec.js
+++ b/tests/srtparser/serialize.spec.js
@@ -31,13 +31,13 @@ test('Success: simple serialization (WebVTT)', () => {
 
 1
 00:00:00.000 --> 00:00:00.001
-- It
-- is
-- wednesday
+It
+is
+wednesday
 
 2
 00:00:00.001 --> 01:01:01.001
-- My dudes`;
+My dudes`;
 
   expect(
     SRTParser.serialize(


### PR DESCRIPTION
This line adds an `-` in the captioning, which doesn't seem to be required?
This line presents itself even when the caption is single line.

Maybe we can explore making this optional.