### PR TITLE
[fix] Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "srt-validator",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "",
   "main": "dist/srtValidator.js",
   "engines": {
@@ -12,12 +12,14 @@
     "prettier": "./scripts/prettier.sh",
     "lint": "eslint src/** tests/**",
     "test": "npm run lint && jest",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "bump:patch": "npm version patch --no-git-tag-version && git add package.json"
   },
   "precommit": [
     "prettier",
     "lint",
-    "test"
+    "test",
+    "bump:patch"
   ],
   "devDependencies": {
     "@babel/core": "^7.16.7",


### PR DESCRIPTION
This repo publish to npm on every new commit that is pushed to the `main` branch.
And npm requires a new version number on publishing. Previously, the developer
need to manually update the version number to make publish successful (and
sometimes if they forget to update the version, it will result in a failure:

Example: https://github.com/taoning2014/srt-validator/actions/runs/1707734150

This commit automates the process by leveraging the pre-commit hook to bump the version.