### PR TITLE
Allow dist folder published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+/node_modules
+/coverage
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+*.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "srt-validator",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "",
   "main": "dist/srtValidator.js",
   "engines": {


### PR DESCRIPTION
Base on the issue #37, srt-validator cannot be used without manually build it. This PR fixes it by allowing the `dist` folder published to npm. This adds the `.npmignore` so npm publish will read it instead of reading the .gitignore which will ignore the dist folder.