### PR TITLE
fix(types): add type definitions to published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "srt-validator",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "",
-  "main": "dist/srtValidator.js",
+  "main": "dist/index.js",
   "engines": {
     "node": ">= 12.22.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
This change fixes an issue where the type definitions were not being included in the published npm package.

fix #44